### PR TITLE
fix: update dependabot config to use current schema

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,12 +20,10 @@ updates:
     labels:
       - "dependencies"
       - "automerge"
-    # Allow all update types for npm dependencies
+    # Allow all dependency types for npm
     allow:
       - dependency-type: "direct"
-        update-type: "all"
       - dependency-type: "indirect"
-        update-type: "all"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -47,7 +45,6 @@ updates:
     labels:
       - "github-actions"
       - "automerge"
-    # Allow all update types for GitHub Actions
+    # Allow direct dependencies for GitHub Actions
     allow:
       - dependency-type: "direct"
-        update-type: "all"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,10 +20,12 @@ updates:
     labels:
       - "dependencies"
       - "automerge"
-    # Only allow automerge for patch and minor updates
+    # Allow all update types for npm dependencies
     allow:
       - dependency-type: "direct"
+        update-type: "all"
       - dependency-type: "indirect"
+        update-type: "all"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -45,6 +47,7 @@ updates:
     labels:
       - "github-actions"
       - "automerge"
-    # Allow automerge for all GitHub Actions updates
+    # Allow all update types for GitHub Actions
     allow:
       - dependency-type: "direct"
+        update-type: "all"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,19 +20,10 @@ updates:
     labels:
       - "dependencies"
       - "automerge"
-    # Automerge rules
-    automerge: true
-    automerge-type: "squash"
     # Only allow automerge for patch and minor updates
     allow:
       - dependency-type: "direct"
-        update-type: "patch"
-      - dependency-type: "direct"
-        update-type: "minor"
       - dependency-type: "indirect"
-        update-type: "patch"
-      - dependency-type: "indirect"
-        update-type: "minor"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -54,14 +45,6 @@ updates:
     labels:
       - "github-actions"
       - "automerge"
-    # Automerge rules for GitHub Actions
-    automerge: true
-    automerge-type: "squash"
     # Allow automerge for all GitHub Actions updates
     allow:
       - dependency-type: "direct"
-        update-type: "patch"
-      - dependency-type: "direct"
-        update-type: "minor"
-      - dependency-type: "direct"
-        update-type: "major"


### PR DESCRIPTION
- Remove unsupported automerge and automerge-type properties
- Remove unsupported update-type properties from allow section
- Maintain automerge labels for manual configuration
- Keep weekly update schedule and reviewer assignments